### PR TITLE
Add support for YAML input

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -12,7 +12,7 @@ module.exports = function () {
   var filepaths = file.arrayify(_.flatten(args));
 
   return _.each(filepaths, function(filepath, index, list) {
-    _.each(file.readJSONSync(filepath).languages, function (lang) {
+    _.each(file.readDataSync(filepath).languages, function (lang) {
       _.each(file.expand(options.patterns).map(function (page) {
         var ext = path.extname(page);
         var parsedData = matter.read(page);


### PR DESCRIPTION
Parser referenced `file.readJSONSync()`, switched for `file.readDataSync()`
Data parsing is entirely `fs-utils` responsibility
