### PR TITLE
adding a proper plugin for i18n and making it work with yfm templates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,18 +26,26 @@ module.exports = function(grunt) {
         partials: 'templates/includes/*.hbs',
         layoutdir: 'templates/layouts',
         layout: 'default.hbs',
+        plugins: ['./index.js']
       },
       i18n_1: {
         options: {
-          pages: pages('data/i18n.json')
+          i18n: {
+            data: 'data/i18n.json'
+          },
+          pages: ['index.hbs']
         },
         dest: '_demo/i18n/',
         src: '!*.*'
       },
       i18n_2: {
         options: {
+          i18n: {
+            data: ['data/i18n.json'],
+            patterns: ['**.hbs']
+          },
           // Second param for passing file patterns
-          pages: pages(['data/i18n.json'], {patterns: ['**.hbs']})
+          pages: ['index.hbs']
         },
         dest: '_demo/i18n/',
         src: '!*.*'

--- a/_demo/i18n-alt/index.html
+++ b/_demo/i18n-alt/index.html
@@ -11,6 +11,7 @@
 <footer>
   <small>Language: fr</small>
   <p>Copyright (c) 2014 Assemble, contributors. Released under the MIT license</p>
+  <p>Your language is fr</p>
 </footer>
 
 	</body>

--- a/_demo/i18n/index-en.html
+++ b/_demo/i18n/index-en.html
@@ -11,6 +11,7 @@
 <footer>
   <small>Language: en</small>
   <p>Copyright (c) 2014 Assemble, contributors. Released under the MIT license</p>
+  <p>Your language is en</p>
 </footer>
 
 	</body>

--- a/_demo/i18n/index-es.html
+++ b/_demo/i18n/index-es.html
@@ -11,6 +11,7 @@
 <footer>
   <small>Language: es</small>
   <p>Copyright (c) 2014 Assemble, contributors. Released under the MIT license</p>
+  <p>Your language is es</p>
 </footer>
 
 	</body>

--- a/_demo/i18n/index-fr.html
+++ b/_demo/i18n/index-fr.html
@@ -11,6 +11,7 @@
 <footer>
   <small>Language: fr</small>
   <p>Copyright (c) 2014 Assemble, contributors. Released under the MIT license</p>
+  <p>Your language is fr</p>
 </footer>
 
 	</body>

--- a/index.hbs
+++ b/index.hbs
@@ -1,9 +1,11 @@
 ---
 copyright: Copyright (c) 2014 Assemble, contributors. Released under the MIT license
+footnote: Your language is <%= language %>
 ---
 <h1>{{i18n "title"}}</h1>
 <p>{{i18n "description"}}</p>
 <footer>
   <small>Language: {{ language }}</small>
   <p>{{ copyright }}</p>
+  <p>{{ footnote }}</p>
 </footer>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,51 @@
+/**
+ * Assemble <http://assemble.io>
+ * Created and maintained by Jon Schlinkert and Brian Woodward
+ *
+ * Copyright (c) 2014 Upstage.
+ * Licensed under the MIT License (MIT).
+ */
+
+var _ = require('lodash');
+var i18n = require('./lib/i18n');
+
+var options = {
+  stage: 'options:post:configuration'
+};
+
+/**
+ * postprocess
+ * @param  {Object}   params
+ * @param  {Function} callback
+ */
+module.exports = function (params, callback) {
+  'use strict';
+
+  var grunt = params.grunt;
+
+  grunt.verbose.subhead('Running:'.bold, '"assemble-contrib-i18n"');
+  grunt.verbose.writeln('Stage:  '.bold, '"' + params.stage + '"\n');
+
+  var opt = params.assemble.options.i18n;
+  grunt.verbose.writeln('Options'.bold, require('util').inspect(opt));
+
+  if (opt) {
+    var data = opt.data;
+    var patterns = opt.patterns;
+
+    var pages = {};
+    if (patterns) {
+      patterns = { patterns: patterns };
+      pages = i18n(data, patterns);
+    } else {
+      pages = i18n(data);
+    }
+
+    params.assemble.options.pages = pages; //_.extend({}, params.assemble.options.pages, pages);
+
+  }
+
+  callback();
+};
+
+module.exports.options = options;

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -11,7 +11,8 @@ module.exports = function () {
 
   var filepaths = file.arrayify(_.flatten(args));
 
-  return _.each(filepaths, function(filepath, index, list) {
+  var pages = {};
+  _.each(filepaths, function(filepath, index) {
     _.each(file.readDataSync(filepath).languages, function (lang) {
       _.each(file.expand(options.patterns).map(function (page) {
         var ext = path.extname(page);
@@ -22,9 +23,9 @@ module.exports = function () {
           data: _.assign({language: lang}, parsedData.context)
         };
       }), function (page) {
-        list.push(page);
+        pages[page.filename] = page;
       });
     });
-    return list;
   });
+  return pages;
 };


### PR DESCRIPTION
This PR creates an actual plugin to generate the pages collection after the configuration has occurred so we don't have to worry about grunt processing the yfm too soon.

Some things still need to be worked on here (like making assemble work even if no source and no pages are supplied at first). These things though should be resolved in the next version of assemble and this plugin can be updated then.
